### PR TITLE
changed env to be an example for new testers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ In the project directory, you can run:
 
 ## If you need HarperDB Functionality to Store Messages
 
-Create a harper db table + schema in your table and then in `server/.env`
-### `HARPERDB_URL="<your HarperDB url"`
-### `HARPERDB_PW="Basic <your HarperDB password key>"`
+Create a harper db table + schema in your table and then
+Rename `server/.env.example` to `server/.env`
+
+### `HARPERDB_URL="<harperDbCloudURL"`
+Replace "harperDbCloudURL" with your hyper DB cloud URL.
+### `HARPERDB_PW="hyperDbPassword"`
+Replace "hyperDbPassword" with your super secret HyperDB password.
 
 Runs the app in the development mode.\
 Open [http://localhost:3000](http://localhost:3000) to view it in your browser.

--- a/server/.env
+++ b/server/.env
@@ -1,4 +1,0 @@
-// server/.env
-
-HARPERDB_URL="https://chat-1-technophyle.harperdbcloud.com"
-HARPERDB_PW="Basic dGVjaG5vOkFkaXR5YQ=="

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,4 @@
+// server/.env
+
+HARPERDB_URL="harperDbCloudURL"
+HARPERDB_PW="hyperDbPassword"


### PR DESCRIPTION
The convention is to put a sample .env file so new users could understand what they should put and where (even if they didn't read the README.md before). this is why it's also called .env.example